### PR TITLE
chores(controller): refactor use Optional to produce 404

### DIFF
--- a/libs/hello-api/src/main/groovy/hello/api/VehicleController.groovy
+++ b/libs/hello-api/src/main/groovy/hello/api/VehicleController.groovy
@@ -3,9 +3,7 @@ package hello.api
 import groovy.transform.CompileStatic
 import hello.legacy.model.Vehicle
 import hello.legacy.model.VehicleRepository
-import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Error
 import io.micronaut.http.annotation.Get
 
 @CompileStatic
@@ -19,22 +17,18 @@ class VehicleController {
     }
 
     @Get('/{id}')
-    VehicleResponse show(Long id) {
-        Vehicle vehicle = vehicleRepository.findById(id).orElse(null)
-        if (!vehicle) {
-            throw new NoSuchElementException("No vehicle found for id: $id")
-        }
+    Optional<VehicleResponse> show(Long id) {
+        return vehicleRepository
+            .findById(id)
+            .map { vehicle -> toResponse(vehicle) }
+    }
+
+    private static VehicleResponse toResponse(Vehicle vehicle) {
         return new VehicleResponse(
-                id: vehicle.id,
-                name: vehicle.name,
-                make: vehicle.make,
-                model: vehicle.model
+            id: vehicle.id,
+            name: vehicle.name,
+            make: vehicle.make,
+            model: vehicle.model
         )
     }
-
-    @Error(exception = NoSuchElementException)
-    HttpResponse<?> noSuchElement(NoSuchElementException e) {
-        return HttpResponse.notFound()
-    }
-
 }


### PR DESCRIPTION
Hi @musketyr great series of articles :clap: :clap: :clap: 

One of the things I've found myself doing a lot is to use the Optional type for representing possible 404 responses. In your code, you are creating a customized 404 response, and I didn't know whether you knew this behavior or you wanted to create a customized 404 message on purpose.

If you only care about returning a 404 I think Optional keeps things cleaner. That's the PR all about.

However if all responses could have a customized 404 message I would create a customized serializer handling a response type of my own to end up with something similar to this:

```groovy
@CompileStatic
@Controller('/vehicle')
class VehicleController {
    private final VehicleRepository vehicleRepository

    VehicleController(VehicleRepository vehicleDataService) {
        this.vehicleRepository = vehicleDataService
    }

    @Get('/{id}')
    ResponseWrapper<Vehicle> show(Long id) {
        return ResponseWrapper.create(vehicleRepository.findById(id), "vehicle with id $id not found")
    }
}
```

To me the serializer approach would worth it only if I wanted to handle exceptions as data, not only 404.